### PR TITLE
Finish implementation of def

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2,33 +2,38 @@ use crate::parser::{Atom, Expression};
 use std::collections::{HashMap, VecDeque};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LockjawRuntimeError<'a> {
-	InvalidArguments(&'a str),
-	InvalidArgumentCount(&'a str),
+pub enum LockjawRuntimeError {
+	InvalidArguments(String),
+	InvalidArgumentCount(String),
 	UnboundExpression,
 }
 
-type Function = fn(VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError>;
+type BuiltinFunction = fn(VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError>;
+
+enum Function {
+	Builtin(BuiltinFunction),
+	Defined(Expression),
+}
 
 pub struct Evaluator {
 	env: HashMap<String, Function>,
 }
 
-impl<'a> Evaluator {
+impl<'a, 'b> Evaluator {
 	fn add(args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
 		if args.is_empty() {
 			return Err(LockjawRuntimeError::InvalidArgumentCount(
-				"+ requires at least one argument.",
+				"+ requires at least one argument.".to_string(),
 			));
 		}
 		let mut accumulator = Atom::Int(0);
 		for expr in args {
 			accumulator = match expr {
 				Expression::SExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"SExpr cannot be an argument for +",
+					"SExpr cannot be an argument for +".to_string(),
 				)),
 				Expression::QExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"QExpr cannot be an argument for +",
+					"QExpr cannot be an argument for +".to_string(),
 				)),
 				Expression::Atom(a) => match (a, accumulator) {
 					(Atom::Float(f), Atom::Float(g)) => Ok(Atom::Float(f + g)),
@@ -37,7 +42,7 @@ impl<'a> Evaluator {
 					(Atom::Int(i), Atom::Int(j)) => Ok(Atom::Int(i + j)),
 					(_, Atom::Symbol(_)) => unreachable!(),
 					(Atom::Symbol(_), _) => Err(LockjawRuntimeError::InvalidArguments(
-						"Cannot add a non-number",
+						"Cannot add a non-number".to_string(),
 					)),
 				},
 			}?
@@ -48,7 +53,7 @@ impl<'a> Evaluator {
 	fn sub(mut args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
 		if args.is_empty() {
 			return Err(LockjawRuntimeError::InvalidArgumentCount(
-				"- requires at least one argument.",
+				"- requires at least one argument.".to_string(),
 			));
 		}
 		let mut accumulator = match args.pop_front().unwrap() {
@@ -57,18 +62,18 @@ impl<'a> Evaluator {
 				Atom::Int(i) => Atom::Int(i),
 				Atom::Symbol(_) => {
 					return Err(LockjawRuntimeError::InvalidArguments(
-						"Expected number got Symbol",
+						"Expected number got Symbol".to_string(),
 					))
 				}
 			},
 			Expression::SExpression(_) => {
 				return Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				))
 			}
 			Expression::QExpression(_) => {
 				return Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				))
 			}
 		};
@@ -84,10 +89,10 @@ impl<'a> Evaluator {
 		for expr in args {
 			accumulator = match expr {
 				Expression::SExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				)),
 				Expression::QExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				)),
 				Expression::Atom(a) => match (accumulator, a) {
 					(Atom::Float(f), Atom::Float(g)) => Ok(Atom::Float(f - g)),
@@ -96,7 +101,7 @@ impl<'a> Evaluator {
 					(Atom::Int(i), Atom::Int(j)) => Ok(Atom::Int(i - j)),
 					(_, Atom::Symbol(_)) => unreachable!(),
 					(Atom::Symbol(_), _) => Err(LockjawRuntimeError::InvalidArguments(
-						"expected number got Symbol",
+						"expected number got Symbol".to_string(),
 					)),
 				},
 			}?
@@ -107,7 +112,7 @@ impl<'a> Evaluator {
 	fn mul(mut args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
 		if args.is_empty() {
 			return Err(LockjawRuntimeError::InvalidArgumentCount(
-				"+ requires at least one argument.",
+				"+ requires at least one argument.".to_string(),
 			));
 		}
 		let mut accumulator = match args.pop_front().unwrap() {
@@ -116,28 +121,28 @@ impl<'a> Evaluator {
 				Atom::Int(i) => Atom::Int(i),
 				Atom::Symbol(_) => {
 					return Err(LockjawRuntimeError::InvalidArguments(
-						"Expected number got Symbol",
+						"Expected number got Symbol".to_string(),
 					))
 				}
 			},
 			Expression::SExpression(_) => {
 				return Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				))
 			}
 			Expression::QExpression(_) => {
 				return Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				))
 			}
 		};
 		for expr in args {
 			accumulator = match expr {
 				Expression::SExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"SExpr cannot be an argument for *",
+					"SExpr cannot be an argument for *".to_string(),
 				)),
 				Expression::QExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"QExpr cannot be an argument for *",
+					"QExpr cannot be an argument for *".to_string(),
 				)),
 				Expression::Atom(a) => match (a, accumulator) {
 					(Atom::Float(f), Atom::Float(g)) => Ok(Atom::Float(f * g)),
@@ -146,7 +151,7 @@ impl<'a> Evaluator {
 					(Atom::Int(i), Atom::Int(j)) => Ok(Atom::Int(i * j)),
 					(_, Atom::Symbol(_)) => unreachable!(),
 					(Atom::Symbol(_), _) => Err(LockjawRuntimeError::InvalidArguments(
-						"Cannot multiply a non-number",
+						"Cannot multiply a non-number".to_string(),
 					)),
 				},
 			}?
@@ -157,7 +162,7 @@ impl<'a> Evaluator {
 	fn div(mut args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
 		if args.is_empty() {
 			return Err(LockjawRuntimeError::InvalidArgumentCount(
-				"+ requires at least one argument.",
+				"+ requires at least one argument.".to_string(),
 			));
 		}
 		let mut accumulator = match args.pop_front().unwrap() {
@@ -166,28 +171,28 @@ impl<'a> Evaluator {
 				Atom::Int(i) => Atom::Int(i),
 				Atom::Symbol(_) => {
 					return Err(LockjawRuntimeError::InvalidArguments(
-						"Expected number got Symbol",
+						"Expected number got Symbol".to_string(),
 					))
 				}
 			},
 			Expression::SExpression(_) => {
 				return Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				))
 			}
 			Expression::QExpression(_) => {
 				return Err(LockjawRuntimeError::InvalidArguments(
-					"Expected number got SExpr",
+					"Expected number got SExpr".to_string(),
 				))
 			}
 		};
 		for expr in args {
 			accumulator = match expr {
 				Expression::SExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"SExpr cannot be an argument for /",
+					"SExpr cannot be an argument for /".to_string(),
 				)),
 				Expression::QExpression(_) => Err(LockjawRuntimeError::InvalidArguments(
-					"QExpr cannot be an argument for /",
+					"QExpr cannot be an argument for /".to_string(),
 				)),
 				Expression::Atom(a) => match (accumulator, a) {
 					(Atom::Float(f), Atom::Float(g)) => Ok(Atom::Float(f / g)),
@@ -196,7 +201,7 @@ impl<'a> Evaluator {
 					(Atom::Int(i), Atom::Int(j)) => Ok(Atom::Float(i as f64 / j as f64)),
 					(_, Atom::Symbol(_)) => unreachable!(),
 					(Atom::Symbol(_), _) => Err(LockjawRuntimeError::InvalidArguments(
-						"Cannot divide a non-number",
+						"Cannot divide a non-number".to_string(),
 					)),
 				},
 			}?
@@ -211,7 +216,7 @@ impl<'a> Evaluator {
 	fn car(mut args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
 		if args.len() != 1 {
 			return Err(LockjawRuntimeError::InvalidArgumentCount(
-				"Car only takes one argument.",
+				"Car only takes one argument.".to_string(),
 			));
 		}
 		if let Expression::QExpression(mut args) = args.pop_front().unwrap() {
@@ -222,7 +227,7 @@ impl<'a> Evaluator {
 			}
 		} else {
 			Err(LockjawRuntimeError::InvalidArguments(
-				"Car can only operate on qexpr",
+				"Car can only operate on qexpr".to_string(),
 			))
 		}
 	}
@@ -230,7 +235,7 @@ impl<'a> Evaluator {
 	fn cdr(mut args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
 		if args.len() != 1 {
 			return Err(LockjawRuntimeError::InvalidArgumentCount(
-				"Cdr only takes one argument.",
+				"Cdr only takes one argument.".to_string(),
 			));
 		}
 		if let Expression::QExpression(mut args) = args.pop_front().unwrap() {
@@ -242,7 +247,7 @@ impl<'a> Evaluator {
 			}
 		} else {
 			Err(LockjawRuntimeError::InvalidArguments(
-				"Cdr can only operate on qexpr",
+				"Cdr can only operate on qexpr".to_string(),
 			))
 		}
 	}
@@ -250,7 +255,7 @@ impl<'a> Evaluator {
 	fn join(mut args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
 		if args.len() != 2 {
 			return Err(LockjawRuntimeError::InvalidArgumentCount(
-				"Join requires two arguments.",
+				"Join requires two arguments.".to_string(),
 			));
 		}
 
@@ -260,28 +265,52 @@ impl<'a> Evaluator {
 				Ok(Expression::QExpression(a))
 			}
 			_ => Err(LockjawRuntimeError::InvalidArguments(
-				"Join can only operate on qexpr.",
+				"Join can only operate on qexpr.".to_string(),
 			)),
 		}
 	}
 
+	fn def(&'a mut self, args: VecDeque<Expression>) -> Result<Expression, LockjawRuntimeError> {
+		if let Some(Expression::QExpression(expressions)) = args.get(0) {
+			if expressions.len() != args.len() - 1 {
+				return Err(LockjawRuntimeError::InvalidArgumentCount(
+					"Def requires one value per variable name".to_string(),
+				));
+			} else {
+				for (token, value) in expressions.iter().zip(args.iter().skip(1)) {
+					if let Expression::Atom(Atom::Symbol(phrase)) = token {
+						self.env
+							.insert(phrase.to_string(), Function::Defined(value.clone()));
+						/*
+						.get_mut(k)
+						.insert(phrase.to_string(), Function::Defined(value.clone()));*/
+					}
+				}
+				return Ok(Expression::SExpression(VecDeque::new()));
+			}
+		}
+		Err(LockjawRuntimeError::InvalidArguments(
+			"First argument to def must be a qexpr!".to_string(),
+		))
+	}
+
 	pub fn new() -> Self {
 		let mut env: HashMap<String, Function> = HashMap::new();
-		env.insert("+".to_string(), Self::add);
-		env.insert("-".to_string(), Self::sub);
-		env.insert("*".to_string(), Self::mul);
-		env.insert("/".to_string(), Self::div);
-		env.insert("quote".to_string(), Self::quote);
-		env.insert("car".to_string(), Self::car);
-		env.insert("cdr".to_string(), Self::cdr);
-		env.insert("join".to_string(), Self::join);
+		env.insert("+".to_string(), Function::Builtin(Self::add));
+		env.insert("-".to_string(), Function::Builtin(Self::sub));
+		env.insert("*".to_string(), Function::Builtin(Self::mul));
+		env.insert("/".to_string(), Function::Builtin(Self::div));
+		env.insert("quote".to_string(), Function::Builtin(Self::quote));
+		env.insert("car".to_string(), Function::Builtin(Self::car));
+		env.insert("cdr".to_string(), Function::Builtin(Self::cdr));
+		env.insert("join".to_string(), Function::Builtin(Self::join));
 
-		Evaluator { env }
+		Evaluator { env: env }
 	}
 
 	fn resolve_sexpression(
-		&'a self,
-		mut expressions: VecDeque<Expression<'a>>,
+		&'a mut self,
+		mut expressions: VecDeque<Expression>,
 	) -> Result<Expression, LockjawRuntimeError> {
 		if expressions.is_empty() {
 			return Ok(Expression::SExpression(expressions));
@@ -289,9 +318,11 @@ impl<'a> Evaluator {
 
 		// Must check for Quote before any evaluation is done
 
-		if let Expression::Atom(Atom::Symbol("quote")) = expressions[0] {
-			expressions.pop_front();
-			return Ok(Expression::QExpression(expressions));
+		if let Some(Expression::Atom(Atom::Symbol(sym))) = expressions.get(0) {
+			if sym == "quote" {
+				expressions.pop_front();
+				return Ok(Expression::QExpression(expressions));
+			}
 		}
 
 		let mut evals = VecDeque::new();
@@ -300,32 +331,46 @@ impl<'a> Evaluator {
 			evals.push_back(self.evaluate(expression)?);
 		}
 
-		if let Expression::Atom(Atom::Symbol(s)) = evals[0] {
+		if let Some(Expression::Atom(Atom::Symbol(s))) = evals.get(0) {
 			if let Some(e) = self.env.get(s) {
 				evals.pop_front(); // Remove operator from list
-				e(evals)
+				match e {
+					Function::Builtin(f) => f(evals),
+					Function::Defined(val) => Ok(val.clone()), // TODO: I hate this a little bit.
+				}
 			} else {
-				if let Expression::Atom(Atom::Symbol("eval")) = evals[0] {
-					evals.pop_front();
-					return if let Some(Expression::QExpression(exprlist)) = evals.pop_front() {
-						self.resolve_sexpression(exprlist)
-					} else {
-						Err(LockjawRuntimeError::InvalidArguments(
-							"Can only eval qexprs!",
-						))
-					};
+				if let Some(Expression::Atom(Atom::Symbol(sym))) = evals.get(0) {
+					if sym == "eval" {
+						evals.pop_front();
+						return if let Some(Expression::QExpression(exprlist)) = evals.pop_front() {
+							self.resolve_sexpression(exprlist)
+						} else {
+							Err(LockjawRuntimeError::InvalidArguments(
+								"Can only eval qexprs!".to_string(),
+							))
+						};
+					}
+				}
+
+				if let Some(Expression::Atom(Atom::Symbol(sym))) = evals.pop_front() {
+					if sym == "def" {
+						println!("{evals:?}");
+						return self.def(evals);
+					}
 				}
 
 				return Err(LockjawRuntimeError::UnboundExpression);
 			}
 		} else {
-			Err(LockjawRuntimeError::InvalidArguments("Invalid Operation"))
+			Err(LockjawRuntimeError::InvalidArguments(
+				"Invalid Operation".to_string(),
+			))
 		}
 	}
 
 	pub fn evaluate(
-		&'a self,
-		expression: Expression<'a>,
+		&'a mut self,
+		expression: Expression,
 	) -> Result<Expression, LockjawRuntimeError> {
 		match expression {
 			Expression::Atom(a) => Ok(Expression::Atom(a)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
 		}
 	};
 
-	let environment = evaluator::Evaluator::new();
+	let mut environment = evaluator::Evaluator::new();
 
 	loop {
 		let readline = rl.readline("lj> ");
@@ -72,7 +72,7 @@ mod tests {
 
 	#[test]
 	fn plus_adds() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "+ 3 4";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -86,7 +86,7 @@ mod tests {
 
 	#[test]
 	fn minus_subtracts() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "- 3 1 1 1 ";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -100,7 +100,7 @@ mod tests {
 
 	#[test]
 	fn minus_negates() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "- 1";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -114,7 +114,7 @@ mod tests {
 
 	#[test]
 	fn math_operations_upcast_to_float() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "+ 1 2.4";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -124,7 +124,7 @@ mod tests {
 		let m = matches!(result, Expression::Atom(Atom::Float(_)));
 		assert!(m);
 
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "- 1 2.4";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -134,7 +134,7 @@ mod tests {
 		let m = matches!(result, Expression::Atom(Atom::Float(_)));
 		assert!(m);
 
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "* 1 2.4";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -144,7 +144,7 @@ mod tests {
 		let m = matches!(result, Expression::Atom(Atom::Float(_)));
 		assert!(m);
 
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "/ 1 2";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -157,7 +157,7 @@ mod tests {
 
 	#[test]
 	fn quote_handles_valid_expressions() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "quote 1 2 4 2 + - * \\ / 34 dsfgsd 345 &";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -170,7 +170,7 @@ mod tests {
 
 	#[test]
 	fn curly_brackets_quote() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "eval {+ 1 2 3}";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -183,20 +183,21 @@ mod tests {
 
 	#[test]
 	fn car_gets_front_element_of_qexpr() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "car {+ 1 2 3}";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
 			.unwrap();
 		let parse = parser::Expression::parse_root(lexemes.as_slice()).unwrap();
 		let result = environment.evaluate(parse).unwrap();
-		let m = matches!(result, Expression::Atom(Atom::Symbol("+")));
-		assert!(m);
+		if let Expression::Atom(Atom::Symbol(sym)) = result {
+			assert_eq!(sym, "+");
+		}
 	}
 
 	#[test]
 	fn cdr_gets_tail_of_qexpr() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "cdr {+ 1 }";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()
@@ -215,7 +216,7 @@ mod tests {
 
 	#[test]
 	fn join_combines_qexprs() {
-		let environment = evaluator::Evaluator::new();
+		let mut environment = evaluator::Evaluator::new();
 		let command = "eval (join {+} {1 2 3})";
 		let lexemes: Vec<lexer::Lexeme> = lexer::Lexer::new(&command)
 			.collect::<Result<Vec<lexer::Lexeme>, parser::LockjawParseError>>()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,14 +7,14 @@ pub enum LockjawParseError {
 	InvalidLiteral { index: usize },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Atom<'a> {
+#[derive(Debug, Clone, PartialEq)]
+pub enum Atom {
 	Float(f64),
 	Int(i64),
-	Symbol(&'a str),
+	Symbol(String),
 }
 
-impl<'a> Display for Atom<'a> {
+impl<'a> Display for Atom {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Atom::Float(v) => write!(f, "Float: {}", v),
@@ -25,13 +25,13 @@ impl<'a> Display for Atom<'a> {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum Expression<'a> {
-	Atom(Atom<'a>),
-	SExpression(VecDeque<Expression<'a>>),
-	QExpression(VecDeque<Expression<'a>>),
+pub enum Expression {
+	Atom(Atom),
+	SExpression(VecDeque<Expression>),
+	QExpression(VecDeque<Expression>),
 }
 
-impl<'a> Expression<'a> {
+impl Expression {
 	pub fn lexeme_len(&self) -> usize {
 		match self {
 			// Open paren, Operator, <expr list> Close Paren.
@@ -45,7 +45,7 @@ impl<'a> Expression<'a> {
 		}
 	}
 
-	pub fn parse(lexemes: &[Lexeme<'a>]) -> Result<Self, LockjawParseError> {
+	pub fn parse(lexemes: &[Lexeme]) -> Result<Self, LockjawParseError> {
 		match lexemes[0].value {
 			LexemeType::LeftParen => {
 				let mut exprlist = VecDeque::new();
@@ -74,7 +74,7 @@ impl<'a> Expression<'a> {
 			term => Ok(Expression::Atom(match term {
 				LexemeType::Integer(value) => Atom::Int(value),
 				LexemeType::Float(value) => Atom::Float(value),
-				LexemeType::RawSymbol(symb) => Atom::Symbol(symb),
+				LexemeType::RawSymbol(symb) => Atom::Symbol(symb.to_string()),
 				_ => {
 					return Err(LockjawParseError::InvalidLiteral {
 						index: lexemes[0].index,
@@ -84,7 +84,7 @@ impl<'a> Expression<'a> {
 		}
 	}
 
-	pub fn parse_root(lexemes: &[Lexeme<'a>]) -> Result<Self, LockjawParseError> {
+	pub fn parse_root(lexemes: &[Lexeme]) -> Result<Self, LockjawParseError> {
 		let mut expressions = VecDeque::new();
 		let mut lexemes_consumed = 0;
 		while lexemes_consumed < lexemes.len() {


### PR DESCRIPTION
So I was having issues with the line `src/evaluator.rs:283` Where originally before I ripped out the `&str` from some of my classes it would complain that the mutable borrow wasn't allowed for reasons I couldnt fully understand.

I would prefer to bring back my string references instead of all the additional unnecessary string copies that this is doing, but im not yet sure how to do so effectively.